### PR TITLE
feat: 面板指令增加干员名校验 / Add operator name validation to panel command

### DIFF
--- a/core/client.py
+++ b/core/client.py
@@ -344,9 +344,9 @@ class EndfieldClient:
             "/api/endfield/achieve", params=p, framework_token=framework_token
         )
 
-    async def get_search_chars(self) -> Optional[Dict]:
+    async def get_search_chars(self, framework_token: str = "") -> Optional[Dict]:
         """GET /api/endfield/search/chars"""
-        return await self._get("/api/endfield/search/chars")
+        return await self._get("/api/endfield/search/chars", framework_token=framework_token)
 
     # ─── Friend (public, no framework_token needed) ───────────────────
     async def get_friend_detail(

--- a/core/client.py
+++ b/core/client.py
@@ -344,9 +344,13 @@ class EndfieldClient:
             "/api/endfield/achieve", params=p, framework_token=framework_token
         )
 
-    async def get_search_chars(self, framework_token: str = "") -> Optional[Dict]:
+    async def get_search_chars(
+        self, framework_token: Optional[str] = None
+    ) -> Optional[Dict]:
         """GET /api/endfield/search/chars"""
-        return await self._get("/api/endfield/search/chars", framework_token=framework_token)
+        return await self._get(
+            "/api/endfield/search/chars", framework_token=framework_token
+        )
 
     # ─── Friend (public, no framework_token needed) ───────────────────
     async def get_friend_detail(

--- a/main.py
+++ b/main.py
@@ -185,6 +185,27 @@ class EndfieldPlugin(Star):
         self._auto_sign_in_task_handle = None
         self._http_client = None
         self.banner_cache = {}
+        self._operator_name_cache: set = set()
+
+    async def _ensure_operator_name_cache(self):
+        """从协议终端拉取全局干员列表并缓存，用于面板指令的正名校验。"""
+        if self._operator_name_cache:
+            return
+        all_bindings = await self.user_mgr.get_all_bindings()
+        for b in all_bindings:
+            token = b.get("framework_token")
+            if not token:
+                continue
+            res = await self.client.get_search_chars(framework_token=token)
+            if res and "chars" in res:
+                for c in res["chars"]:
+                    name = c.get("name", "")
+                    if name:
+                        self._operator_name_cache.add(name)
+                logger.info(
+                    f"[Endfield] 干员名称缓存已就绪，共 {len(self._operator_name_cache)} 名干员"
+                )
+                return
 
     def _get_server_name(self, acc: dict) -> str:
         """从账号对象中获取可读的服务器名称。"""
@@ -2132,6 +2153,11 @@ class EndfieldPlugin(Star):
             "菜单",
             "帮助",
         }:
+            return
+
+        # Guard: only proceed if char_name is a known operator
+        await self._ensure_operator_name_cache()
+        if self._operator_name_cache and char_name not in self._operator_name_cache:
             return
 
         user_id = event.get_sender_id()

--- a/main.py
+++ b/main.py
@@ -187,25 +187,21 @@ class EndfieldPlugin(Star):
         self.banner_cache = {}
         self._operator_name_cache: set = set()
 
-    async def _ensure_operator_name_cache(self):
-        """从协议终端拉取全局干员列表并缓存，用于面板指令的正名校验。"""
+    async def _ensure_operator_name_cache(self, token: str):
+        """用当前用户的 token 拉取全局干员列表并缓存。已缓存则直接返回 True。"""
         if self._operator_name_cache:
-            return
-        all_bindings = await self.user_mgr.get_all_bindings()
-        for b in all_bindings:
-            token = b.get("framework_token")
-            if not token:
-                continue
-            res = await self.client.get_search_chars(framework_token=token)
-            if res and "chars" in res:
-                for c in res["chars"]:
-                    name = c.get("name", "")
-                    if name:
-                        self._operator_name_cache.add(name)
-                logger.info(
-                    f"[Endfield] 干员名称缓存已就绪，共 {len(self._operator_name_cache)} 名干员"
-                )
-                return
+            return True
+        res = await self.client.get_search_chars(framework_token=token)
+        if not res or "chars" not in res:
+            return False
+        for c in res["chars"]:
+            name = c.get("name", "")
+            if name:
+                self._operator_name_cache.add(name)
+        logger.info(
+            f"[Endfield] 干员名称缓存已就绪，共 {len(self._operator_name_cache)} 名干员"
+        )
+        return True
 
     def _get_server_name(self, acc: dict) -> str:
         """从账号对象中获取可读的服务器名称。"""
@@ -2155,20 +2151,25 @@ class EndfieldPlugin(Star):
         }:
             return
 
-        # Guard: only proceed if char_name is a known operator
-        await self._ensure_operator_name_cache()
-        if self._operator_name_cache and char_name not in self._operator_name_cache:
-            return
-
         user_id = event.get_sender_id()
         binding = await self.user_mgr.get_primary_binding(user_id)
         if not binding:
-            yield event.plain_result("未绑定账号。")
+            yield event.plain_result("未绑定账号，请输入 /zmd 查看绑定方式。")
+            return
+
+        token = binding.get("framework_token")
+
+        # Guard: only proceed if char_name is a known operator
+        cache_ok = await self._ensure_operator_name_cache(token)
+        if not cache_ok:
+            yield event.plain_result(
+                "您的登录凭证已过期，请重新发送「授权登陆」或「扫码绑定」。"
+            )
+            return
+        if self._operator_name_cache and char_name not in self._operator_name_cache:
             return
 
         yield event.plain_result(f"正在查询 {char_name} 的面板...")
-
-        token = binding.get("framework_token")
         note = await self.client.get_note(
             token, binding["role_id"], int(binding.get("server_id", 1))
         )

--- a/main.py
+++ b/main.py
@@ -186,18 +186,21 @@ class EndfieldPlugin(Star):
         self._http_client = None
         self.banner_cache = {}
         self._operator_name_cache: set = set()
+        self._cache_ts = 0
 
     async def _ensure_operator_name_cache(self, token: str):
-        """用当前用户的 token 拉取全局干员列表并缓存。已缓存则直接返回 True。"""
-        if self._operator_name_cache:
+        """用当前用户的 token 拉取全局干员列表并缓存。24h 有效期。"""
+        if self._operator_name_cache and time.time() - self._cache_ts < 86400:
             return True
         res = await self.client.get_search_chars(framework_token=token)
         if not res or "chars" not in res:
             return False
+        self._operator_name_cache.clear()
         for c in res["chars"]:
             name = c.get("name", "")
             if name:
                 self._operator_name_cache.add(name)
+        self._cache_ts = time.time()
         logger.info(
             f"[Endfield] 干员名称缓存已就绪，共 {len(self._operator_name_cache)} 名干员"
         )


### PR DESCRIPTION
  改动内容：
  1. core/client.py — get_search_chars() 补全 framework_token 参数（此前遗漏，直接调用会返回 40301）
  2. main.py — xx面板 指令增加干员名白名单校验：
    - 新增 _ensure_operator_name_cache(token) 方法，用当前用户的 token 调用 get_search_chars 拉取全局干员列表并缓存
    - 缓存有效期 24 小时，过期后下次请求自动刷新
    - 提取的干员名不在白名单中则静默丢弃，避免任意文本误触发面板指令
    - token 无效时提示用户重新授权绑定
  效果：
  之前：任意 xx面板 文本都会触发正则处理
  之后：只有 莱万汀面板、庄方宜面板、陈千语面板 等真实干员名才会响应
Changes:
  1. core/client.py — Added missing framework_token parameter to get_search_chars() (the endpoint returns 40301 without
  it)
  2. main.py — Added operator name whitelist validation to the xx面板 command:
    - New _ensure_operator_name_cache(token) method fetches the global operator list via get_search_chars using the
  caller's own token, cached in memory
    - 24-hour TTL on the cache, auto-refreshes on next request after expiry
    - Extracted character names not in the whitelist are silently dropped, preventing arbitrary text from matching the
  regex handler
    - Expired/invalid tokens surface a clear "please re-authorize" error to the user
  Before:  xx面板 pattern triggered the handler
  After: Only real operator names like 莱万汀面板, 陈千语面板 pass the gate